### PR TITLE
fix index out of range

### DIFF
--- a/src/encryption/cfb8.rs
+++ b/src/encryption/cfb8.rs
@@ -29,6 +29,9 @@ impl<E: Encoding> Cfb8Encryption<E> {
     }
 
     fn raw_decrypt(ciphertext: Vec<u8>, key: &AesKey) -> Result<String, NcrError> {
+        if ciphertext.len() < 8 {
+            return Err(NcrError::DecryptError);
+        }
         let nonce: [u8; 8] = ciphertext[..8].try_into().unwrap();
 
         let iv = generate_iv(u64::from_be_bytes(nonce));


### PR DESCRIPTION
thread 'main' panicked at 'range end index 8 out of range for slice of length 3', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/ncr-0.1.1/src/encryption/cfb8.rs:32:30
